### PR TITLE
:beers: Allow `.tool-versions` file for installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ Each Dockerfile utilizes the following build arguments:
 
 The `asdf_image`  and `packages` arguments are optional. If not provided, the build will default to installing the latest version of asdf and no plugins.
 
+### Adding Your Own `.tool-versions` File on Build
+
+You can add your own `.tool-versions` file, for example:
+
+```text
+package_name1 version_number
+package_name2 version_number
+```
+
+Naming the file `.tool-versions` will automatically detect the file and `COPY` it to the image on build.
+
+To add a custom file (e.g., using a different name), you need to use the Docker `COPY` command and set ASDF's environment variable correctly:
+
+```dockerfile
+WORKDIR /tmp/  # Only required if you want to put the file in a different location from the default `/asdf/`
+ENV ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=custom-tool-version
+COPY custom-tool-version ./
+RUN bash /init/install-asdf-package
+```
+See the [asdf reference for more details](https://asdf-vm.com/manage/configuration.html#tool-versions).
+
 ## Getting Started
 
 To get started, follow these steps:

--- a/base-images/Dockerfile.alpine
+++ b/base-images/Dockerfile.alpine
@@ -46,6 +46,9 @@ COPY --from=builder /go/bin/asdf /usr/local/bin/asdf
 ONBUILD ARG packages=""
 ONBUILD ENV ASDF_PACKAGES=$packages
 
+# Copy .tool-versions if it exist on build
+ONBUILD COPY --chown=asdf:asdf *.tool-versions /asdf/
+
 # Ensure ASDF packages are installed when the derived image is built
 ONBUILD USER asdf
 ONBUILD RUN bash /init/install-asdf-package

--- a/base-images/Dockerfile.debian
+++ b/base-images/Dockerfile.debian
@@ -51,6 +51,9 @@ COPY --from=builder /go/bin/asdf /usr/local/bin/asdf
 ONBUILD ARG packages=""
 ONBUILD ENV ASDF_PACKAGES=$packages
 
+# Copy .tool-versions if it exist on build
+ONBUILD COPY --chown=asdf:asdf *.tool-versions /asdf/
+
 # Ensure ASDF packages are installed when the derived image is built
 ONBUILD USER asdf
 ONBUILD RUN bash /init/install-asdf-package

--- a/bin/install-asdf-package
+++ b/bin/install-asdf-package
@@ -52,10 +52,21 @@ install_package() {
         fi
 
         if [ "$default_package" == "set" ]; then
-            "$asdf_cli" set "$package_name" "$package_version"
+            "$asdf_cli" set "$package_name" "$package_version" || echo "setting $package_name:$package_version failed"
         fi
     fi
 }
+
+# If ASDF_DEFAULT_TOOL_VERSIONS_FILENAME is found Loop over and install packages
+tool_versions=$(asdf info | grep ASDF_DEFAULT_TOOL_VERSIONS_FILENAME | cut -d= -f2)
+if [ -f "$tool_versions" ]; then
+    while read -r line; do
+        package_name=$(echo "$line" | awk '{print $1}')
+        package_version=$(echo "$line" | awk '{print $2}')
+        default_package=""
+        install_package "$package_name" "$package_version" "$default_package"
+    done <"$tool_versions"
+fi
 
 # Loop through each plugin in the PACKAGES array
 for package in "${PACKAGES[@]}"; do
@@ -66,6 +77,5 @@ for package in "${PACKAGES[@]}"; do
         package_version=""
         default_package=""
     fi
-
     install_package "$package_name" "$package_version" "$default_package"
 done


### PR DESCRIPTION
Allow users to add thier own `.tool-version` file during docker `ONBUILD` steps. This will check if the `.tool-versions` file exist and COPY over to users image and add the plugins ready for installs.

#patch

**TODO:**

- [x] Add details to README file
- [x] Add examples